### PR TITLE
Resource name constraints. Closes #59.

### DIFF
--- a/datapackagist/src/scripts/components/ui/descriptoredit.js
+++ b/datapackagist/src/scripts/components/ui/descriptoredit.js
@@ -31,7 +31,7 @@ DataUploadView = backbone.BaseView.extend({
             schema = jtsInfer(D[0], _.rest(D));
 
             this.options.form.getEditor('root.resources').addRow({
-              name: EV.target.name,
+              name: _.last(EV.target.name.split('/')).toLowerCase().replace(/\.[^.]+$|[^a-z^\-^\d^_^\.]+/g, ''),
               path: EV.target.name,
               schema: schema
             });


### PR DESCRIPTION
Convert path into resource name
* remove extension
* remove all chars except alpha-numeric, ```-```, ```_``` and ```.```
* remove extension (last dotted part of the file name).