### PR TITLE
Populate descriptor edit form with remote data. Closes #57.

### DIFF
--- a/datapackagist/src/scripts/components/ui/registry.js
+++ b/datapackagist/src/scripts/components/ui/registry.js
@@ -32,6 +32,8 @@ module.exports = {
 
     reset: function(collection) {
       backbone.BaseListView.prototype.reset.call(this, collection);
+
+      // Used to restore previous value when user selects No in confirmation dialog
       this.selectedValue = this.$(this.options.container).val();
 
       $.getJSON(this.getSelectedSchema(), (function(schemaData) {

--- a/datapackagist/src/scripts/components/ui/registry.js
+++ b/datapackagist/src/scripts/components/ui/registry.js
@@ -28,11 +28,13 @@ module.exports = {
                   this.selectedValue = id;
                   this.parent.reset(schemaData);
                   window.APP.layout.confirmationDialog.deactivate();
+                  return false;
                 }).bind(this),
 
                 no: (function() {
                   this.$(this.options.container).val(this.selectedValue);
                   window.APP.layout.confirmationDialog.deactivate();
+                  return false;
                 }).bind(this)
               })
 

--- a/datapackagist/src/scripts/components/ui/registry.js
+++ b/datapackagist/src/scripts/components/ui/registry.js
@@ -7,7 +7,45 @@ var deep = require('deep-diff');
 module.exports = {
   ListView: backbone.BaseListView.extend({
     events: {
-      'change': function(event) { this.setSelectedSchema(this.$(this.options.container).val()); }
+      'change': function(event) {
+        var id = this.$(this.options.container).val();
+
+
+        $.getJSON(this.collection.get(id).get('schema'), (function(schemaData) {
+          var
+            // Keys of entered fields
+            keys = _.keys(this.parent.getFilledValues());
+
+          this.schemaData = schemaData;
+
+          // If data can be lost - show confirmation message
+          if(deep.diff(_.pick(schemaData.properties, keys), _.pick(this.parent.layout.form.schema.properties, keys)))
+            return window.APP.layout.confirmationDialog
+              .setMessage('Some data you have entered will be lost. Are you sure you want to change the Data Package Profile?')
+
+              .setCallbacks({
+                yes: (function() {
+
+                  this.selectedValue = id;
+                  this.parent.reset(schemaData);
+                  window.APP.layout.confirmationDialog.deactivate();
+                }).bind(this),
+
+                no: (function() {
+                  this.$(this.options.container).val(this.selectedValue);
+                  window.APP.layout.confirmationDialog.deactivate();
+                }).bind(this)
+              })
+
+              .activate();
+
+          else
+
+            this.selectedValue = id;
+
+          this.parent.reset(schemaData);
+        }).bind(this));
+      }
     },
 
     // Returns schema object
@@ -32,61 +70,24 @@ module.exports = {
 
     reset: function(collection) {
       backbone.BaseListView.prototype.reset.call(this, collection);
-
-      // Used to restore previous value when user selects No in confirmation dialog
-      this.selectedValue = this.$(this.options.container).val();
-
-      $.getJSON(this.getSelectedSchema(), (function(schemaData) {
-        this.schemaData = schemaData;
-        this.parent.reset(schemaData);
-      }).bind(this));
-
+      this.setSelected(this.collection.at(0).get('id'));
       return this;
     },
 
     // Update selectbox and trigger change event
-    setSelectedSchema: function(id) {
+    setSelected: function(id) {
       this.$(this.options.container).val(id);
+
+      // Used to restore previous value when user selects No in confirmation dialog
+      this.selectedValue = id;
 
       return new Promise((function(RS, RJ) {
         $.getJSON(this.collection.get(id).get('schema'), (function(schemaData) {
-          var
-            // Keys of entered fields
-            keys = _.keys(this.parent.getFilledValues());
-
           this.schemaData = schemaData;
-
-          // If data can be lost - show confirmation message
-          if(deep.diff(_.pick(schemaData.properties, keys), _.pick(this.parent.layout.form.schema.properties, keys)))
-            return window.APP.layout.confirmationDialog
-              .setMessage('Some data you have entered will be lost. Are you sure you want to change the Data Package Profile?')
-
-              .setCallbacks({
-                yes: (function() {
-                  this.selectedValue = this.$(this.options.container).val();
-                  this.parent.reset(schemaData);
-                  window.APP.layout.confirmationDialog.deactivate();
-                  RS(schemaData);
-                }).bind(this),
-
-                no: (function() {
-                  this.$(this.options.container).val(this.selectedValue);
-                  window.APP.layout.confirmationDialog.deactivate();
-                  RS(schemaData);
-                }).bind(this)
-              })
-
-              .activate();
-
-          else
-            this.selectedValue = this.$(this.options.container).val();
-
           this.parent.reset(schemaData);
           RS(schemaData);
         }).bind(this));
       }).bind(this));
-
-      return this;
     },
 
     tagName: 'select'

--- a/datapackagist/src/scripts/components/ui/registry.js
+++ b/datapackagist/src/scripts/components/ui/registry.js
@@ -25,7 +25,6 @@ module.exports = {
 
               .setCallbacks({
                 yes: (function() {
-
                   this.selectedValue = id;
                   this.parent.reset(schemaData);
                   window.APP.layout.confirmationDialog.deactivate();
@@ -38,9 +37,7 @@ module.exports = {
               })
 
               .activate();
-
           else
-
             this.selectedValue = id;
 
           this.parent.reset(schemaData);

--- a/datapackagist/src/scripts/components/ui/registry.js
+++ b/datapackagist/src/scripts/components/ui/registry.js
@@ -46,7 +46,7 @@ module.exports = {
 
     // Update selectbox and trigger change event
     setSelectedSchema: function(id) {
-      this.$el.val(id);
+      this.$(this.options.container).val(id);
 
       return new Promise((function(RS, RJ) {
         $.getJSON(this.collection.get(id).get('schema'), (function(schemaData) {

--- a/datapackagist/src/scripts/router.js
+++ b/datapackagist/src/scripts/router.js
@@ -1,6 +1,8 @@
 var _ = require('underscore');
 var backbone = require('backbone');
+var dpFromRemote = require('datapackage-from-remote');
 var registry = require('datapackage-registry');
+var Promise = require('bluebird');
 
 // WARN Used just for demo purposes
 var VALID_DESCRIPTOR = {
@@ -24,6 +26,7 @@ var VALID_DESCRIPTOR = {
 module.exports = backbone.Router.extend({
   routes: {
     '(/)': 'index',
+    'from-remote/:datapackage(/)': 'fromRemote',
     'validation-results/:resource(/)': 'validationResults'
   },
 
@@ -38,6 +41,22 @@ module.exports = backbone.Router.extend({
     return this;
   },
 
+  fromRemote: function(datapackage) {
+    var options = _.object(window.location.search.replace('?', '').split('&').map(function(P) { return P.split('='); }));
+
+    // If .index() have not yet downloaded registry it will return Promise. Otherwise
+    // registry is loaded and .index() returns undefined.
+    (this.index() || new Promise(function(RS, RJ) { RS(true); })).then(function() {
+      try {
+        dpFromRemote(unescape(options.url), _.extend(options, {datapackage: datapackage}))
+        .then(function(D) { console.log(D); })
+        .catch(function(E) { console.log('Error while processing data: ' + E); });
+      } catch(E) {
+        console.log('Error while loading data from remote: ' + E);
+      }
+    });
+  },
+
   index: function() {
     this.deactivateAll();
     window.APP.layout.navbar.toggleBadge(true);
@@ -48,7 +67,8 @@ module.exports = backbone.Router.extend({
 
     // WARN Process registry errors here
     if(!window.APP.layout.descriptorEdit.layout.registryList.collection)
-      registry.get().then(function(D) {
+      // fromRemote route need to wait for registry before getting datapackage from remote source
+      return registry.get().then(function(D) {
         window.APP.layout.descriptorEdit.layout.registryList.reset(new backbone.Collection(D));
       });
   },

--- a/datapackagist/src/scripts/router.js
+++ b/datapackagist/src/scripts/router.js
@@ -42,6 +42,7 @@ module.exports = backbone.Router.extend({
   },
 
   fromRemote: function(datapackage) {
+    var descriptorEdit = window.APP.layout.descriptorEdit;
     var options = _.object(window.location.search.replace('?', '').split('&').map(function(P) { return P.split('='); }));
 
     // If .index() have not yet downloaded registry it will return Promise. Otherwise
@@ -49,8 +50,14 @@ module.exports = backbone.Router.extend({
     (this.index() || new Promise(function(RS, RJ) { RS(true); })).then(function() {
       try {
         dpFromRemote(unescape(options.url), _.extend(options, {datapackage: datapackage}))
-        .then(function(D) { console.log(D); })
-        .catch(function(E) { console.log('Error while processing data: ' + E); });
+          .then(function(D) {
+            // Update registry and descriptor schema list and then set descriptor form value
+            descriptorEdit.layout.registryList.setSelected(datapackage).then(function() {
+              descriptorEdit.layout.form.setValue(D);
+            });
+          })
+
+          .catch(function(E) { console.log('Error while processing data: ' + E); });
       } catch(E) {
         console.log('Error while loading data from remote: ' + E);
       }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,7 +40,7 @@ function scriptPipeline(bundle, outfile) {
   return bundle
            .pipe(source(outfile))
            .pipe(buffer())
-           // .pipe(uglify())
+           .pipe(uglify())
            .pipe(gulp.dest(distDir));
 
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,7 +40,7 @@ function scriptPipeline(bundle, outfile) {
   return bundle
            .pipe(source(outfile))
            .pipe(buffer())
-           .pipe(uglify())
+           // .pipe(uglify())
            .pipe(gulp.dest(distDir));
 
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -69,9 +69,10 @@ gulp.task('serve', function() {
   browserSync({
     open: false,
     server: {
-        baseDir: distDir
+        baseDir: distDir,
+
         // use this for apps with client side routing
-        // middleware: [historyApiFallback]
+        middleware: [historyApiFallback()]
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -12,9 +12,12 @@
   "dependencies": {
     "backbone": "^1.2.0",
     "backbone-base": "^0.0.2",
+    "bluebird": "^2.9.30",
     "bootstrap": "^3.3.4",
     "browserify-handlebars": "^1.0.0",
+    "connect-history-api-fallback": "^1.1.0",
     "csv": "^0.4.5",
+    "datapackage-from-remote": "0.0.2",
     "datapackage-outfile": "^0.1.0",
     "datapackage-registry": "^0.1.0",
     "datapackage-validate": "git://github.com/okfn/datapackage-validate.git#feature/datapackage-registry",


### PR DESCRIPTION
* Added route for working with remote data
* use https://github.com/okfn/datapackage-from-remote-js for fetching and mapping remote source into datapackage
* did some related refactoring in registry list view.

Example URL — http://127.0.0.1:3000/from-remote/base/?source=ckan&version=3.0&url=http%3A%2F%2Fdatahub.io%2Fapi%2Faction%2Fpackage_show%3Fid%3Dpopulation-number-by-governorate-age-group-and-gender-2010-2014&oq=asdf+http%3A%2F%2Fdatahub.io%2Fapi%2Faction%2Fpackage_show%3Fid%3Dpopulation-number-by-governorate-age-group-and-gender-2010-2014&format=json