### PR TITLE
Disable field type selection. Closes #76.

### DIFF
--- a/datapackagist/src/scripts/components/ui/descriptoredit.js
+++ b/datapackagist/src/scripts/components/ui/descriptoredit.js
@@ -260,6 +260,9 @@ module.exports = {
           // Expand resources section if there are any resources, collapse if row is empty
           if(resourcesLength && resources.collapsed || !resourcesLength && !resources.collapsed)
             $(resources.toggle_button).trigger('click');
+
+          // Do not allow changing schema field type — disable type selectbox
+          this.$('[data-schemapath]:not([data-schematype]) select.form-control').prop('hidden', true);
         }).bind(this)));
 
         $('#json-code').prop('hidden', true);

--- a/datapackagist/src/scripts/components/ui/descriptoredit.js
+++ b/datapackagist/src/scripts/components/ui/descriptoredit.js
@@ -153,15 +153,15 @@ module.exports = {
       // Customize theme
       JSONEditor.defaults.iconlibs.fontawesome4 = JSONEditor.defaults.iconlibs.fontawesome4.extend({
         mapping: {
-          collapse: 'minus',
-          expand: 'plus',
-          'delete': 'times',
-          edit: 'pencil',
-          add: 'plus',
-          cancel: 'ban',
-          save: 'save',
-          moveup: 'arrow-up',
-          movedown: 'arrow-down'
+          'collapse': 'minus',
+          'expand'  : 'plus',
+          'delete'  : 'times',
+          'edit'    : 'pencil',
+          'add'     : 'plus',
+          'cancel'  : 'ban',
+          'save'    : 'save',
+          'moveup'  : 'arrow-up',
+          'movedown': 'arrow-down'
         }
       });
 


### PR DESCRIPTION
Field type selection is rendered for fields which are not described in schema. Like items of Resource Schema array.

In this PR disabled all field type selectors, for any section. As it is not typical for schema to have fields with no type described.