### PR TITLE
Render all schema defined fields in array item row. Closes #75.

### DIFF
--- a/datapackagist/src/scripts/components/ui/descriptoredit.js
+++ b/datapackagist/src/scripts/components/ui/descriptoredit.js
@@ -43,7 +43,7 @@ DataUploadView = backbone.BaseView.extend({
               name: _.last(EV.target.name.split('/')).toLowerCase().replace(/\.[^.]+$|[^a-z^\-^\d^_^\.]+/g, ''),
               path: EV.target.name,
               schema: schema
-            });
+            }, true);
 
             // Save data source in the form
             _.last(this.options.form.getEditor('root.resources').rows).dataSource = {schema: schema, data: EV.result};


### PR DESCRIPTION
Allow showing even empty schema fields when add new item with values. Was disabled before.