### PR TITLE
Global tracking of name value

### DIFF
--- a/datapackagist/src/scripts/components/ui/descriptoredit.js
+++ b/datapackagist/src/scripts/components/ui/descriptoredit.js
@@ -93,7 +93,7 @@ module.exports = {
 
     events: {
       // Populate main title and resource title fields
-      'keyup input[name="root[name]"], [data-schemapath^="root.resources."].container-name input': function(event) {
+      'keyup [data-schemapath].container-name input': function(event) {
         var $input = $(event.currentTarget);
         var $title = $input.closest('[data-schematype=object]').find('.row .container-title input').eq(0);
 
@@ -107,7 +107,7 @@ module.exports = {
 
       // Do not populate title field with name field data if title was edited
       // by user. Consider it is not edited once user empties it.
-      'keyup input[name="root[title]"], [data-schemapath^="root.resources."].container-title input': function(event) {
+      'keyup [data-schemapath].container-title input': function(event) {
         var $input = $(event.currentTarget);
 
 

--- a/datapackagist/src/scripts/components/ui/descriptoredit.js
+++ b/datapackagist/src/scripts/components/ui/descriptoredit.js
@@ -282,6 +282,14 @@ module.exports = {
 
           // Do not allow changing schema field type — disable type selectbox
           this.$('[data-schemapath]:not([data-schematype]) select.form-control').prop('hidden', true);
+
+          // Populate empty title fields with name field value. Rely on DOM events defined
+          // in DescriptorEditView.events
+          _.each($('[data-schemapath].container-title input', this.layout.form.getEditor('root').container), function(I) {
+            I.edited = Boolean($(I).val());
+          });
+
+          $('[data-schemapath].container-name input', this.layout.form.getEditor('root').container).trigger('keyup');
         }).bind(this)));
 
         $('#json-code').prop('hidden', true);

--- a/datapackagist/src/scripts/components/ui/descriptoredit.js
+++ b/datapackagist/src/scripts/components/ui/descriptoredit.js
@@ -97,6 +97,7 @@ module.exports = {
         var $input = $(event.currentTarget);
         var $title = $input.closest('[data-schematype=object]').find('.row .container-title input').eq(0);
 
+
         // Do not populate user changed field
         if($title[0].edited)
           return true;

--- a/datapackagist/src/scripts/components/ui/descriptoredit.js
+++ b/datapackagist/src/scripts/components/ui/descriptoredit.js
@@ -99,7 +99,7 @@ module.exports = {
 
 
         // Do not populate user changed field
-        if($title[0].edited)
+        if(_.result($title[0], 'edited'))
           return true;
 
         $title.val(titleize($input.val()));


### PR DESCRIPTION
* Any row with fields named ```title``` and ```name``` will populate ```title``` from ```name``` if user didn't edit ```title``` himself
* populate empty ```title``` on form change (data file or data package updaloded or schema changed).