### PR TITLE
Do not validate empty properties

### DIFF
--- a/datapackagist/src/scripts/components/ui/download.js
+++ b/datapackagist/src/scripts/components/ui/download.js
@@ -1,3 +1,4 @@
+var _ = require('underscore');
 var backbone = require('backbone');
 var backboneBase = require('backbone-base');
 var outfile = require('datapackage-outfile');
@@ -7,10 +8,21 @@ var validator = require('datapackage-validate');
 // Download validated datapackage
 module.exports = backbone.BaseView.extend({
   reset: function(descriptor, schema) {
+    var form = window.APP.layout.descriptorEdit.layout.form;
+
+
     this.$el.addClass('disabled');
 
-    validator.validate(window.APP.layout.descriptorEdit.layout.form.getValue(), schema).then((function(R) {
-      if(R.valid)
+    validator.validate(form.getValue(), schema).then((function(R) {
+      var errors = _.filter(R.errors, function(E) {
+        var editor = form.getEditor('root' + E.dataPath.replace(/\//g, '.'));
+        var isRequired = _.contains(editor.parent.schema.required, editor.key);
+
+
+        return isRequired || !isRequired && editor.getValue();
+      });
+
+      if(!errors.length)
         this.$el
           .removeClass('disabled')
 


### PR DESCRIPTION
```datapackage-validate``` validates properties over specified pattern even if it is empty. For now I just filter validation error of empty non-required properties.

But proper solution would be omitting empty properties from resulting datapackage json. It requires some efforts as should be done recursively, probably with respect to some specifics of datapackage structure.