### PR TITLE
Validation UX. Closes #97.

### DIFF
--- a/datapackagist/dist/index.html
+++ b/datapackagist/dist/index.html
@@ -102,7 +102,6 @@
 
         <div class="col-md-7" id="validate-buttons">
 
-            <button type="button" class="btn btn-sm btn-info">Validate Schema</button>
             <button type="button" id="validate-resources" class="btn btn-sm btn-info">Validate Resources</button>
 
         </div>

--- a/datapackagist/src/scripts/components/ui/descriptoredit.js
+++ b/datapackagist/src/scripts/components/ui/descriptoredit.js
@@ -268,6 +268,7 @@ module.exports = {
       this.layout.form = new JSONEditor(this.$('[data-id=form-container]').get(0), {
         schema: schema,
         show_errors: 'change',
+        remove_empty_properties: true,
         theme: 'bootstrap3',
         disable_edit_json: true,
         disable_properties: true,

--- a/datapackagist/src/scripts/components/ui/descriptoredit.js
+++ b/datapackagist/src/scripts/components/ui/descriptoredit.js
@@ -267,6 +267,7 @@ module.exports = {
 
       this.layout.form = new JSONEditor(this.$('[data-id=form-container]').get(0), {
         schema: schema,
+        show_errors: 'change',
         theme: 'bootstrap3',
         disable_edit_json: true,
         disable_properties: true,
@@ -274,7 +275,7 @@ module.exports = {
       });
 
       // Remove Top-level collapse button
-      this.layout.form.root.toggle_button.remove()
+      this.layout.form.root.toggle_button.remove();
 
       // Bind local event to form nodes after form is renedered
       this.delegateEvents();

--- a/datapackagist/src/scripts/components/ui/descriptoredit.js
+++ b/datapackagist/src/scripts/components/ui/descriptoredit.js
@@ -268,7 +268,6 @@ module.exports = {
       this.layout.form = new JSONEditor(this.$('[data-id=form-container]').get(0), {
         schema: schema,
         show_errors: 'change',
-        remove_empty_properties: true,
         theme: 'bootstrap3',
         disable_edit_json: true,
         disable_properties: true,

--- a/datapackagist/src/scripts/components/ui/descriptoredit.js
+++ b/datapackagist/src/scripts/components/ui/descriptoredit.js
@@ -268,6 +268,7 @@ module.exports = {
       this.layout.form = new JSONEditor(this.$('[data-id=form-container]').get(0), {
         schema: schema,
         show_errors: 'change',
+        remove_empty_properties: true,
         theme: 'bootstrap3',
         disable_edit_json: true,
         disable_properties: true,
@@ -329,7 +330,7 @@ module.exports = {
 
 
           // Empty array data should have one empty item
-          if(_.contains(['resources', 'sources', 'licences'], E.dataset.schemapath.replace('root.', '')))
+          if(_.contains(['resources'], E.dataset.schemapath.replace('root.', '')))
             $(editor.add_row_button).trigger('click');
 
           if(isEmpty && !editor.collapsed)

--- a/datapackagist/src/scripts/components/ui/download.js
+++ b/datapackagist/src/scripts/components/ui/download.js
@@ -13,6 +13,7 @@ module.exports = backbone.BaseView.extend({
 
     this.$el.addClass('disabled');
 
+    // Drop errors of empty fields which are actually not required
     validator.validate(form.getValue(), schema).then((function(R) {
       var errors = _.filter(R.errors, function(E) {
         var editor = form.getEditor('root' + E.dataPath.replace(/\//g, '.'));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,7 +40,7 @@ function scriptPipeline(bundle, outfile) {
   return bundle
            .pipe(source(outfile))
            .pipe(buffer())
-           // .pipe(uglify())
+           .pipe(uglify())
            .pipe(gulp.dest(distDir));
 
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,7 +40,7 @@ function scriptPipeline(bundle, outfile) {
   return bundle
            .pipe(source(outfile))
            .pipe(buffer())
-           .pipe(uglify())
+           // .pipe(uglify())
            .pipe(gulp.dest(distDir));
 
 }


### PR DESCRIPTION
* Added ```json-editor``` option to remove empty text properties
* do not add empty nested items into collapsed properties which type is array — it may cause serious UX issue.

There is still a validation issue related to ```.anyOf``` property of the registry profile — https://www.dropbox.com/s/zzj4fdd7iynbxp5/%D0%A1%D0%BA%D1%80%D0%B8%D0%BD%D1%88%D0%BE%D1%82%202015-07-16%2014.44.16.png?dl=0

Currently we don't have UI to let usere now that **any** of the listed field should not be empty.