### PR TITLE
Prevent validation on startup. Closes #109.

### DIFF
--- a/datapackagist/src/scripts/components/ui/descriptoredit.js
+++ b/datapackagist/src/scripts/components/ui/descriptoredit.js
@@ -270,7 +270,7 @@ module.exports = {
 
           // Empty array data should have one empty item
           if(_.contains(['resources'], E.dataset.schemapath.replace('root.', '')) && !editor.rows.length)
-            $(editor.add_row_button).trigger('click');
+            editor.addRow();
 
           if(isEmpty && !editor.collapsed)
             $(editor.toggle_button).trigger('click');

--- a/datapackagist/src/scripts/components/ui/download.js
+++ b/datapackagist/src/scripts/components/ui/download.js
@@ -30,14 +30,22 @@ module.exports = backbone.BaseView.extend({
 
       // Place .anyOf validation errors on form
       _.each(errors, function(E) {
-        if(parseInt(E.code) === 10)
-          form.getEditor(convertPath(E.dataPath)).showValidationErrors([{
-            message: 'Any of these fields should not be empty: ' + _.map(E.subErrors, function(E) {
-              return E.params.key;
-            }).join(', '),
+        var editor = form.getEditor(convertPath(E.dataPath));
 
-            path: convertPath(E.dataPath)
-          }]);
+
+        if(parseInt(E.code) !== 10)
+          return false;
+
+        editor.showValidationErrors([{
+          message: 'Any of these fields should not be empty: ' + _.map(E.subErrors, function(E) {
+            return E.params.key;
+          }).join(', '),
+
+          path: convertPath(E.dataPath)
+        }]);
+
+        // Previous .showValidationErrors() strips nested editors errors — restore them
+        _.each(editor.editors, function(V, K) { V.showValidationErrors(V.jsoneditor.validation_results); });
       });
 
       if(!errors.length && !_.isEmpty(descriptor))

--- a/datapackagist/src/scripts/components/ui/download.js
+++ b/datapackagist/src/scripts/components/ui/download.js
@@ -40,7 +40,7 @@ module.exports = backbone.BaseView.extend({
           }]);
       });
 
-      if(!errors.length)
+      if(!errors.length && !_.isEmpty(descriptor))
         this.$el
           .removeClass('disabled')
 


### PR DESCRIPTION
* Changed the way how empty items added into object editors. It caused form to fire change event.
* not related to this issue — fixed rendering object editors errors, which stripped nested editors errors.