### PR TITLE
Fix upload empty values issue. Closes #114.

### DIFF
--- a/datapackagist/src/scripts/components/ui/upload.js
+++ b/datapackagist/src/scripts/components/ui/upload.js
@@ -24,6 +24,10 @@ module.exports = backbone.BaseView.extend({
 
             descriptor = JSON.parse(EV.result);
 
+            // If descriptor have field not from schema - reject it
+            if(_.difference(_.keys(descriptor), _.keys(this.parent.layout.form.schema.properties)).length)
+              return false;
+
             // If there are no changes in current form just apply uploaded
             // data and leave
             if(!this.parent.hasChanges()) {
@@ -53,7 +57,7 @@ module.exports = backbone.BaseView.extend({
 
   // Update edit form and download URL
   updateApp: function(descriptor) {
-    this.parent.layout.form.setValue(descriptor);
+    this.parent.layout.form.setValue(_.defaults(descriptor, this.parent.layout.form.getValue()));
     return this;
   }
 });


### PR DESCRIPTION
Uploading data package with empty properties will not remove fields from json-editor form.