### PR TITLE
Fix Safari bug

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,11 +18,16 @@ var path = require('path');
 var streamqueue = require('streamqueue');
 
 var baseDir = './datapackagist';
+var backendDependencies = ['express']
 var srcDir = baseDir + '/src';
 var distDir = baseDir + '/dist';
 var stylesDir = srcDir + '/styles';
 var scriptsDir = srcDir + '/scripts';
-var frontendDependencies = _.keys(require('./package.json').dependencies);
+
+var frontendDependencies = _.chain(require('./package.json').dependencies)
+  .omit(backendDependencies)
+  .keys()
+  .value();
 
 
 /**

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,7 +18,7 @@ var path = require('path');
 var streamqueue = require('streamqueue');
 
 var baseDir = './datapackagist';
-var backendDependencies = ['express']
+var backendDependencies = ['express'];
 var srcDir = baseDir + '/src';
 var distDir = baseDir + '/dist';
 var stylesDir = srcDir + '/styles';


### PR DESCRIPTION
Bug occurs because of ```use strict``` mode applied in one of packages, bundled into ```vendor.min.js```. Luckily it was ```express.js``` which is only required by backend.

Added exclusion of backend dependencies during bundling ```vendor.min.js```.