### PR TITLE
Encode the download URL so spaces are preserved

### DIFF
--- a/datapackagist/src/scripts/components/ui/download.js
+++ b/datapackagist/src/scripts/components/ui/download.js
@@ -52,9 +52,9 @@ module.exports = backbone.BaseView.extend({
         this.$el
           .removeClass('disabled')
 
-          .attr('href', outfile(descriptor, {
+          .attr('href', encodeURI(outfile(descriptor, {
             IE9: window.APP.browser.name == 'ie' && parseInt(window.APP.browser.version.split('.')[0]) <= 9
-          }));
+          })));
     }).bind(this));
 
     return this;


### PR DESCRIPTION
Otherwise all spaces are removed from the JSON that gets downloaded.

See screenshot.

![datapackagist](https://cloud.githubusercontent.com/assets/3272/9991857/9ae363b2-6065-11e5-803f-4e99ea288430.png)